### PR TITLE
Change romanovich23 to romangzz as librevents maintainer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ teams:
     maintainers:
       - tkuhrt
     members:
-      - romanovich23
+      - romangzz
       - adovale-IOB
   - name: one-attestation-api-maintainers
     maintainers:


### PR DESCRIPTION
I've recently changed my GitHub username from `romanovich23` to `romangzz`. This PR updates the repository configuration to reflect my new username and restores my maintainer permissions.

Thanks!