### PR TITLE
Delete ap3-maintainers from configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,11 +10,6 @@ teams:
       - mikelodder7
     members:
       - nglaeser
-  - name: ap3-maintainers
-    maintainers:
-      - ryjones
-    members:
-      - fridgebuyer
   - name: aries-bbs-maintainers
     maintainers:
       - andrewwhitehead


### PR DESCRIPTION
Removed 'ap3-maintainers' group from config.

This moved to another org.